### PR TITLE
feat: initial Culture Kings CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# ck-outfitter-cli
+
+A minimal terminal-only demo that helps you build a Culture Kings cart using **public** endpoints only.
+No private Shopify APIs. No payments. Just product discovery and cart permalinks.
+
+## Quick start
+```bash
+pnpm install
+cp .env.example .env        # set OPENAI_API_KEY for LLM parsing (optional)
+pnpm dev
+```
+
+Type something like:
+```
+I want a red shirt and matching cargo trousers (size M, budget $150).
+```
+
+The agent suggests a few shirts and pants, lets you request more options,
+and can offer matching items if you only asked for one category.
+Pick what you like and the CLI prints a cart link:
+```
+https://culturekings.com.au/cart/<variantId1>:1,<variantId2>:1
+```
+Open the link in a browser to see the prefilled cart.
+
+## Scripts
+- `pnpm dev` – start the CLI
+- `pnpm test` – run unit tests (Vitest)
+
+## Safety & Limitations
+- Uses only public product pages and search results; be gentle with requests.
+- Product pages may change without notice; the demo may break.
+- If a variant can’t be resolved, the CLI prints the product page URL instead.
+- No automatic checkout or payment.
+
+This is a learning/demo tool—use responsibly.

--- a/Readme
+++ b/Readme
@@ -1,1 +1,0 @@
-First File

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ck-outfitter-cli",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "cheerio": "^1.0.0-rc.12",
+    "inquirer": "^9.0.0",
+    "openai": "^4.0.0",
+    "pino": "^8.0.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^0.34.0"
+  }
+}

--- a/src/agent/intent.ts
+++ b/src/agent/intent.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import OpenAI from 'openai';
+import type { Intent, IntentItem } from '../core/types.js';
+
+const itemSchema = z.object({
+  category: z.enum(['shirt', 'pants']),
+  color: z.string().optional(),
+  size: z.string().optional(),
+  budgetCents: z.number().optional(),
+});
+
+const intentSchema = z.object({
+  items: z.array(itemSchema),
+  notes: z.string().optional(),
+});
+
+export async function parseIntent(input: string): Promise<Intent> {
+  const key = process.env.OPENAI_API_KEY;
+  if (key) {
+    try {
+      const client = new OpenAI({ apiKey: key });
+      const resp = await client.chat.completions.create({
+        model: 'gpt-3.5-turbo',
+        temperature: 0,
+        messages: [
+          { role: 'system', content: 'Extract shopping intent for Culture Kings. Respond in JSON.' },
+          { role: 'user', content: input },
+        ],
+      });
+      const txt = resp.choices[0].message?.content || '{}';
+      return intentSchema.parse(JSON.parse(txt));
+    } catch {
+      /* fall back */
+    }
+  }
+
+  // Rule-based fallback
+  const lower = input.toLowerCase();
+  const items: IntentItem[] = [];
+  if (lower.includes('shirt')) items.push({ category: 'shirt' });
+  if (lower.includes('pant')) items.push({ category: 'pants' });
+
+  const colorMatch = lower.match(/\b(red|black|white)\b/);
+  const sizeMatch = lower.match(/size\s*([a-z0-9]+)/);
+  const budgetMatch = lower.match(/\$?\s*(\d+)/);
+
+  for (const item of items) {
+    if (colorMatch) item.color = colorMatch[1];
+    if (sizeMatch) item.size = sizeMatch[1];
+    if (budgetMatch) item.budgetCents = Number(budgetMatch[1]) * 100;
+  }
+
+  return { items };
+}

--- a/src/agent/plan.ts
+++ b/src/agent/plan.ts
@@ -1,0 +1,55 @@
+import type { Intent, Suggestion, IntentItem } from '../core/types.js';
+import { findHandles } from '../shops/culturekings/finder.js';
+import { fetchProductJson } from '../shops/culturekings/productJson.js';
+import { fetchProductFromHtml } from '../shops/culturekings/htmlParser.js';
+import { matchVariant } from '../core/match.js';
+import { rankSuggestions } from '../core/rank.js';
+
+async function resolveHandle(handle: string) {
+  try {
+    return await fetchProductJson(handle);
+  } catch {
+    return await fetchProductFromHtml(handle);
+  }
+}
+
+async function suggestForItem(item: IntentItem, limit = 5): Promise<Suggestion[]> {
+  const handles = await findHandles({ category: item.category, color: item.color, limit });
+  const suggestions: Suggestion[] = [];
+
+  for (const handle of handles) {
+    try {
+      const product = await resolveHandle(handle);
+      const summary = {
+        store: 'culturekings' as const,
+        handle,
+        url: `https://culturekings.com.au/products/${handle}`,
+        title: product.title,
+        image: product.images?.[0]?.src,
+        priceCents: product.price ? Number(product.price) * 100 : undefined,
+        currency: 'AUD' as const,
+        options: product.options?.reduce((acc: Record<string, string[]>, o: any) => {
+          acc[o.name] = o.values;
+          return acc;
+        }, {}),
+      };
+      const pick = matchVariant(product, { Color: item.color, Size: item.size });
+      suggestions.push({ product: summary, pick });
+    } catch {
+      /* ignore individual failures */
+    }
+  }
+
+  return rankSuggestions(suggestions, item);
+}
+
+export async function plan(intent: Intent, limit = 5): Promise<Record<'shirt' | 'pants', Suggestion[]>> {
+  const result: Record<'shirt' | 'pants', Suggestion[]> = { shirt: [], pants: [] };
+  for (const item of intent.items) {
+    const sugs = await suggestForItem(item, limit);
+    result[item.category] = sugs.slice(0, 3);
+  }
+  return result;
+}
+
+export { suggestForItem };

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -1,0 +1,28 @@
+import { setTimeout as delay } from 'timers/promises';
+
+const UA = 'ck-outfitter-cli/0.1 (+https://example.com)';
+
+export async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': UA, Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+export async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': UA, Accept: 'text/html' },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.text();
+}
+
+let last = 0;
+export async function rateLimited<T>(fn: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  const diff = now - last;
+  if (diff < 500) await delay(500 - diff);
+  last = Date.now();
+  return fn();
+}

--- a/src/core/match.ts
+++ b/src/core/match.ts
@@ -1,0 +1,40 @@
+import { VariantPick } from './types.js';
+import { normalizeColor, normalizeSize, normalizeOptionName } from './normalize.js';
+
+export function matchVariant(product: any, desired: Record<string, string | undefined>): VariantPick {
+  const desiredColor = normalizeColor(desired.Color ?? desired.Colour);
+  const desiredSize = normalizeSize(desired.Size);
+
+  const optNames = product.options.map((o: any) => normalizeOptionName(o.name));
+
+  for (const variant of product.variants) {
+    let ok = true;
+    const chosen: Record<string, string> = {};
+    variant.options.forEach((val: string, idx: number) => {
+      const key = optNames[idx];
+      const normVal = normalizeOptionName(val);
+
+      if (key === 'color' || key === 'colour') {
+        const vColor = normalizeColor(normVal);
+        if (desiredColor && vColor !== desiredColor) ok = false;
+        chosen[key] = val;
+      } else if (key === 'size') {
+        const vSize = normalizeSize(normVal);
+        if (desiredSize && vSize !== desiredSize) ok = false;
+        chosen[key] = val;
+      } else {
+        chosen[key] = val;
+      }
+    });
+
+    if (ok) {
+      return {
+        variantId: String(variant.id),
+        inStock: variant.available,
+        chosenOptions: chosen,
+      };
+    }
+  }
+
+  return { variantId: null, chosenOptions: {} };
+}

--- a/src/core/normalize.ts
+++ b/src/core/normalize.ts
@@ -1,0 +1,23 @@
+const COLOR_MAP: Record<string, string[]> = {
+  red: ['red', 'crimson', 'burgundy', 'maroon'],
+  black: ['black'],
+  white: ['white'],
+};
+
+export function normalizeColor(input?: string): string | undefined {
+  if (!input) return undefined;
+  const lower = input.toLowerCase();
+  for (const [base, variants] of Object.entries(COLOR_MAP)) {
+    if (variants.includes(lower)) return base;
+  }
+  return lower;
+}
+
+export function normalizeSize(input?: string): string | undefined {
+  if (!input) return undefined;
+  return input.trim().toUpperCase();
+}
+
+export function normalizeOptionName(name: string): string {
+  return name.trim().toLowerCase();
+}

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -1,0 +1,29 @@
+import { Suggestion } from './types.js';
+import { normalizeColor } from './normalize.js';
+
+export function rankSuggestions(
+  sugs: Suggestion[],
+  desired: { color?: string; size?: string; budgetCents?: number }
+): Suggestion[] {
+  return sugs
+    .map((s) => {
+      let score = 0;
+      const desiredColor = normalizeColor(desired.color);
+      const pickedColor = normalizeColor(s.pick?.chosenOptions?.color || s.pick?.chosenOptions?.colour);
+      if (desiredColor && pickedColor === desiredColor) score += 2;
+
+      if (desired.size && s.pick?.chosenOptions?.size?.toUpperCase() === desired.size.toUpperCase())
+        score += 2;
+
+      if (
+        desired.budgetCents &&
+        s.product.priceCents &&
+        s.product.priceCents <= desired.budgetCents
+      )
+        score += 1;
+
+      return { s, score };
+    })
+    .sort((a, b) => b.score - a.score)
+    .map((x) => x.s);
+}

--- a/src/core/robots.ts
+++ b/src/core/robots.ts
@@ -1,0 +1,4 @@
+export async function allowed(_url: string): Promise<boolean> {
+  // Placeholder – real implementation would fetch and parse robots.txt.
+  return true;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,38 @@
+export type IntentItem = {
+  category: 'shirt' | 'pants';
+  color?: string;
+  size?: string;
+  budgetCents?: number;
+};
+
+export type Intent = {
+  items: IntentItem[];
+  notes?: string;
+};
+
+export type ProductSummary = {
+  store: 'culturekings';
+  handle: string;
+  url: string;
+  title: string;
+  image?: string;
+  priceCents?: number;
+  currency?: 'AUD';
+  options?: Record<string, string[]>;
+};
+
+export type VariantPick = {
+  variantId: string | null;
+  inStock?: boolean;
+  chosenOptions: Record<string, string>;
+};
+
+export type Suggestion = {
+  product: ProductSummary;
+  pick: VariantPick | null;
+};
+
+export type CartLink = {
+  url: string;
+  items: { variantId: string; quantity: number }[];
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,98 @@
+import pino from 'pino';
+import inquirer from 'inquirer';
+import { askDescription, pickSuggestion } from './ui/prompt.js';
+import { parseIntent } from './agent/intent.js';
+import { plan } from './agent/plan.js';
+import { buildCartLink } from './shops/culturekings/cartLink.js';
+import type { IntentItem, Suggestion } from './core/types.js';
+
+const log = pino({ level: 'info' });
+
+async function handleItem(item: IntentItem, label: string): Promise<Suggestion | null> {
+  let limit = 5;
+  let current = item;
+  for (;;) {
+    const res = await plan({ items: [current] }, limit);
+    const choice = await pickSuggestion(res[item.category], label, true);
+    if (choice === 'more') {
+      limit += 5;
+      continue;
+    }
+    if (!choice) {
+      const { retry } = await inquirer.prompt<{ retry: boolean }>([
+        { type: 'confirm', name: 'retry', message: `No ${label} selected. Try a new search?`, default: false },
+      ]);
+      if (!retry) return null;
+      const desc = await askDescription(`Describe the ${label} you want:`);
+      const newIntent = await parseIntent(desc);
+      const newItem = newIntent.items.find((i) => i.category === item.category);
+      if (!newItem) return null;
+      current = newItem;
+      limit = 5;
+      continue;
+    }
+    return choice;
+  }
+}
+
+async function main() {
+  console.log('Culture Kings outfitter demo. Uses public endpoints only.\n');
+
+  const desc = await askDescription();
+  const intent = await parseIntent(desc);
+
+  if (intent.items.length === 0) {
+    console.log('No valid intent found.');
+    return;
+  }
+
+  let shirt: Suggestion | null = null;
+  let pants: Suggestion | null = null;
+
+  for (const item of intent.items) {
+    if (item.category === 'shirt') shirt = await handleItem(item, 'shirt');
+    else if (item.category === 'pants') pants = await handleItem(item, 'pants');
+  }
+
+  if (!pants) {
+    const { want } = await inquirer.prompt<{ want: boolean }>([
+      { type: 'confirm', name: 'want', message: 'Would you like matching pants?', default: false },
+    ]);
+    if (want) {
+      const descP = await askDescription('Describe the pants you want:');
+      const intentP = await parseIntent(descP);
+      const itemP = intentP.items.find((i) => i.category === 'pants');
+      if (itemP) pants = await handleItem(itemP, 'pants');
+    }
+  }
+
+  if (!shirt) {
+    const { want } = await inquirer.prompt<{ want: boolean }>([
+      { type: 'confirm', name: 'want', message: 'Would you like to see shirts?', default: false },
+    ]);
+    if (want) {
+      const descS = await askDescription('Describe the shirt you want:');
+      const intentS = await parseIntent(descS);
+      const itemS = intentS.items.find((i) => i.category === 'shirt');
+      if (itemS) shirt = await handleItem(itemS, 'shirt');
+    }
+  }
+
+  const items = [] as { variantId: string; quantity: number }[];
+  if (shirt?.pick?.variantId) items.push({ variantId: shirt.pick.variantId, quantity: 1 });
+  if (pants?.pick?.variantId) items.push({ variantId: pants.pick.variantId, quantity: 1 });
+
+  if (items.length) {
+    const link = buildCartLink(items);
+    console.log('\nCart link:', link.url);
+  } else {
+    if (shirt) console.log('Shirt page:', shirt.product.url);
+    if (pants) console.log('Pants page:', pants.product.url);
+    console.log('Could not build cart link automatically.');
+  }
+}
+
+main().catch((err) => {
+  log.error(err);
+  process.exit(1);
+});

--- a/src/shops/culturekings/cartLink.ts
+++ b/src/shops/culturekings/cartLink.ts
@@ -1,0 +1,10 @@
+import type { CartLink } from '../../core/types.js';
+
+export function buildCartLink(items: { variantId: string; quantity: number }[]): CartLink {
+  if (!items.length) throw new Error('No items');
+  const parts = items.map((i) => `${i.variantId}:${i.quantity}`);
+  return {
+    url: `https://culturekings.com.au/cart/${parts.join(',')}`,
+    items,
+  };
+}

--- a/src/shops/culturekings/finder.ts
+++ b/src/shops/culturekings/finder.ts
@@ -1,0 +1,43 @@
+import { load } from 'cheerio';
+import { fetchText, fetchJson, rateLimited } from '../../core/http.js';
+
+const TYPE_FILTER: Record<'shirt' | 'pants', RegExp[]> = {
+  shirt: [/tee/i, /shirt/i, /t[-\s]?shirt/i],
+  pants: [/pant/i, /cargo/i, /jean/i],
+};
+
+export async function findHandles(opts: { category: 'shirt' | 'pants'; color?: string; limit: number }): Promise<string[]> {
+  const query = encodeURIComponent([opts.color, opts.category].filter(Boolean).join(' '));
+  const suggest = `https://culturekings.com.au/search/suggest.json?q=${query}&resources%5Btype%5D=product&resources%5Blimit%5D=${opts.limit}`;
+  const regexes = TYPE_FILTER[opts.category];
+
+  try {
+    const data = await rateLimited(() => fetchJson(suggest));
+    const products = data?.resources?.results?.products ?? [];
+    const handles = products
+      .filter((p: any) => regexes.some((r) => r.test(p.product_type || '')))
+      .map((p: any) => p.handle);
+    if (handles.length) return handles.slice(0, opts.limit);
+  } catch {
+    /* fall back */
+  }
+
+  const url = `https://culturekings.com.au/search?q=${query}`;
+  const html = await rateLimited(() => fetchText(url));
+  const $ = load(html);
+  const handles: string[] = [];
+
+  $('a[href*="/products/"]').each((_, el) => {
+    if (handles.length >= opts.limit) return false;
+    const href = $(el).attr('href') || '';
+    const match = href.match(/\/products\/([\w-]+)/);
+    if (match) {
+      const handle = match[1];
+      if (regexes.some((r) => r.test(handle)) && !handles.includes(handle)) {
+        handles.push(handle);
+      }
+    }
+  });
+
+  return handles;
+}

--- a/src/shops/culturekings/htmlParser.ts
+++ b/src/shops/culturekings/htmlParser.ts
@@ -1,0 +1,22 @@
+import { load } from 'cheerio';
+import { fetchText } from '../../core/http.js';
+
+export async function fetchProductFromHtml(handle: string): Promise<any> {
+  const url = `https://culturekings.com.au/products/${handle}`;
+  const html = await fetchText(url);
+  const $ = load(html);
+
+  const script = $('script[type="application/ld+json"]').first().html();
+  if (script) {
+    try {
+      return JSON.parse(script);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const data = $('[data-product-json]').attr('data-product-json');
+  if (data) return JSON.parse(data);
+
+  throw new Error('Product JSON not found in HTML');
+}

--- a/src/shops/culturekings/productJson.ts
+++ b/src/shops/culturekings/productJson.ts
@@ -1,0 +1,6 @@
+import { fetchJson } from '../../core/http.js';
+
+export async function fetchProductJson(handle: string): Promise<any> {
+  const url = `https://culturekings.com.au/products/${handle}.js`;
+  return fetchJson(url);
+}

--- a/src/ui/prompt.ts
+++ b/src/ui/prompt.ts
@@ -1,0 +1,35 @@
+import inquirer from 'inquirer';
+import type { Suggestion } from '../core/types.js';
+
+export async function askDescription(message = 'Describe what you want:'): Promise<string> {
+  const { desc } = await inquirer.prompt<{ desc: string }>([
+    { type: 'input', name: 'desc', message },
+  ]);
+  return desc;
+}
+
+export async function pickSuggestion(
+  sugs: Suggestion[],
+  label: string,
+  allowMore = false
+): Promise<Suggestion | 'more' | null> {
+  if (sugs.length === 0) return null;
+
+  const choices = sugs.map((s, i) => ({
+    name: `${i + 1}. ${s.product.title} - ${
+      s.product.priceCents ? '$' + (s.product.priceCents / 100).toFixed(2) : 'N/A'
+    } (${s.product.url})`,
+    value: String(i),
+  }));
+
+  if (allowMore) choices.push({ name: 'Show me more', value: '__more' });
+  choices.push({ name: 'None of these', value: '__none' });
+
+  const { choice } = await inquirer.prompt<{ choice: string }>([
+    { type: 'list', name: 'choice', message: `Select a ${label}:`, choices },
+  ]);
+
+  if (choice === '__more') return 'more';
+  if (choice === '__none') return null;
+  return sugs[Number(choice)];
+}

--- a/tests/cartLink.test.ts
+++ b/tests/cartLink.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { buildCartLink } from '../src/shops/culturekings/cartLink.js';
+
+describe('cartLink', () => {
+  it('builds correct cart URL', () => {
+    const link = buildCartLink([
+      { variantId: '111', quantity: 1 },
+      { variantId: '222', quantity: 1 },
+    ]);
+    expect(link.url).toBe('https://culturekings.com.au/cart/111:1,222:1');
+  });
+});

--- a/tests/match.test.ts
+++ b/tests/match.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { matchVariant } from '../src/core/match.js';
+
+describe('match', () => {
+  it('matches color synonyms and size (case-insensitive)', () => {
+    const product = {
+      options: [{ name: 'Color' }, { name: 'Size' }],
+      variants: [
+        { id: 1, available: true, options: ['Crimson', 'M'] },
+        { id: 2, available: true, options: ['Blue', 'M'] },
+      ],
+    };
+
+    const pick = matchVariant(product, { Color: 'Red', Size: 'm' });
+    expect(pick.variantId).toBe('1');
+  });
+});

--- a/tests/productJson.test.ts
+++ b/tests/productJson.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchProductJson } from '../src/shops/culturekings/productJson.js';
+
+describe('productJson', () => {
+  it('fetches and parses product JSON', async () => {
+    const product = { title: 'Test', options: [{ name: 'Color', values: ['Red'] }], variants: [] };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(product))));
+    const data = await fetchProductJson('test');
+    expect(data.title).toBe('Test');
+    expect(data.options[0].name).toBe('Color');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- refine product finder to use search suggestions and filter by product type for relevance
- add interactive loop that offers more options and matching categories in the CLI
- update prompts and docs to describe the multi-step agent workflow

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e4f3dec4832599a94edbca83b7d6