### PR TITLE
feat: add optional LangSmith tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,67 @@ https://culturekings.com.au/cart/<variantId1>:1,<variantId2>:1
 ```
 Open the link in a browser to see the prefilled cart.
 
+## Architecture
+
+The CLI is composed of a few small nodes that pass data along a linear path:
+
+- **UI prompts** (`src/ui/prompt.ts`) ask for a free-form description and later
+  let you pick from ranked suggestions.
+- **Intent parser** (`src/agent/intent.ts`) turns the description into a typed
+  `Intent` using OpenAI when an API key is supplied, or a rule-based fallback
+  otherwise.
+- **Planner** (`src/agent/plan.ts`) searches Culture Kings for matching
+  products, resolves their variants and ranks them.
+- **Cart builder** (`src/shops/culturekings/cartLink.ts`) converts the chosen
+  variants into a shareable cart URL.
+
+Data flows from the user ➜ intent ➜ suggestions ➜ feedback ➜ cart link.
+
+### LangSmith tracing
+
+To record a trace of a run, export the following environment variables before
+starting the CLI:
+
+```bash
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY="<your LangSmith key>"
+export LANGCHAIN_PROJECT="ck-outfitter-cli"
+```
+
+Traces will then appear in your LangSmith project for inspection.
+
+## Transcript
+
+An example run with feedback-driven selections and the resulting cart link:
+
+```
+$ pnpm dev
+Culture Kings outfitter demo. Uses public endpoints only.
+
+Describe what you want:
+> I want a red shirt and matching cargo trousers, size M, budget $150.
+
+Select a shirt:
+  1. Example Shirt - $79.95 (https://culturekings.com.au/products/example-shirt)
+  2. Another Shirt - $89.95 (...)
+> 1
+
+Select a pants:
+  1. Example Cargo - $120.00 (https://culturekings.com.au/products/example-cargo)
+  2. Another Cargo - $99.95 (...)
+> 2
+
+Cart link: https://culturekings.com.au/cart/11111111111111:1,22222222222222:1
+```
+
 ## Scripts
 - `pnpm dev` – start the CLI
 - `pnpm test` – run unit tests (Vitest)
 
 ## Safety & Limitations
-- Uses only public product pages and search results; be gentle with requests.
+- Uses only public product pages and search results; no private or authenticated
+  APIs.
+- The demo does not throttle requests—keep usage light to avoid rate limiting.
 - Product pages may change without notice; the demo may break.
 - If a variant can’t be resolved, the CLI prints the product page URL instead.
 - No automatic checkout or payment.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",
     "inquirer": "^9.0.0",
+    "langsmith": "^0.1.1",
     "openai": "^4.0.0",
     "pino": "^8.0.0",
     "zod": "^3.0.0"

--- a/src/agent/intent.ts
+++ b/src/agent/intent.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import OpenAI from 'openai';
 import type { Intent, IntentItem } from '../core/types.js';
+import { withTrace } from '../core/trace.js';
 
 const itemSchema = z.object({
   category: z.enum(['shirt', 'pants']),
@@ -14,7 +15,7 @@ const intentSchema = z.object({
   notes: z.string().optional(),
 });
 
-export async function parseIntent(input: string): Promise<Intent> {
+async function _parseIntent(input: string): Promise<Intent> {
   const key = process.env.OPENAI_API_KEY;
   if (key) {
     try {
@@ -52,3 +53,5 @@ export async function parseIntent(input: string): Promise<Intent> {
 
   return { items };
 }
+
+export const parseIntent = withTrace('parseIntent', _parseIntent);

--- a/src/agent/plan.ts
+++ b/src/agent/plan.ts
@@ -4,6 +4,7 @@ import { fetchProductJson } from '../shops/culturekings/productJson.js';
 import { fetchProductFromHtml } from '../shops/culturekings/htmlParser.js';
 import { matchVariant } from '../core/match.js';
 import { rankSuggestions } from '../core/rank.js';
+import { withTrace } from '../core/trace.js';
 
 async function resolveHandle(handle: string) {
   try {
@@ -43,7 +44,7 @@ async function suggestForItem(item: IntentItem): Promise<Suggestion[]> {
   return rankSuggestions(suggestions, item);
 }
 
-export async function plan(intent: Intent): Promise<Record<'shirt' | 'pants', Suggestion[]>> {
+async function _plan(intent: Intent): Promise<Record<'shirt' | 'pants', Suggestion[]>> {
   const result: Record<'shirt' | 'pants', Suggestion[]> = { shirt: [], pants: [] };
   for (const item of intent.items) {
     const sugs = await suggestForItem(item);
@@ -51,3 +52,5 @@ export async function plan(intent: Intent): Promise<Record<'shirt' | 'pants', Su
   }
   return result;
 }
+
+export const plan = withTrace('plan', _plan);

--- a/src/core/trace.ts
+++ b/src/core/trace.ts
@@ -1,0 +1,22 @@
+type AsyncFn = (...args: any[]) => Promise<any>;
+
+let cachedTraceable: ((fn: AsyncFn, opts: { name: string }) => AsyncFn) | null = null;
+
+async function getTraceable() {
+  if (cachedTraceable) return cachedTraceable;
+  try {
+    const mod: any = await import('langsmith');
+    cachedTraceable = mod.traceable;
+  } catch {
+    cachedTraceable = (fn: AsyncFn) => fn;
+  }
+  return cachedTraceable;
+}
+
+export function withTrace<T extends AsyncFn>(name: string, fn: T): T {
+  return (async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+    const trace = await getTraceable();
+    const wrapped = trace(fn, { name });
+    return wrapped(...args);
+  }) as T;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,11 @@ import { askDescription, pickSuggestion } from './ui/prompt.js';
 import { parseIntent } from './agent/intent.js';
 import { plan } from './agent/plan.js';
 import { buildCartLink } from './shops/culturekings/cartLink.js';
+import { withTrace } from './core/trace.js';
 
 const log = pino({ level: 'info' });
 
-async function main() {
+async function _main() {
   console.log('Culture Kings outfitter demo. Uses public endpoints only.\n');
 
   const desc = await askDescription();
@@ -27,7 +28,8 @@ async function main() {
   if (pants?.pick?.variantId) items.push({ variantId: pants.pick.variantId, quantity: 1 });
 
   if (items.length) {
-    const link = buildCartLink(items);
+    const tracedBuild = withTrace('buildCartLink', async (its: typeof items) => buildCartLink(its));
+    const link = await tracedBuild(items);
     console.log('\nCart link:', link.url);
   } else {
     if (shirt) console.log('Shirt page:', shirt.product.url);
@@ -35,6 +37,8 @@ async function main() {
     console.log('Could not build cart link automatically.');
   }
 }
+
+const main = withTrace('main', _main);
 
 main().catch((err) => {
   log.error(err);

--- a/src/ui/prompt.ts
+++ b/src/ui/prompt.ts
@@ -1,14 +1,15 @@
 import inquirer from 'inquirer';
 import type { Suggestion } from '../core/types.js';
+import { withTrace } from '../core/trace.js';
 
-export async function askDescription(): Promise<string> {
+async function _askDescription(): Promise<string> {
   const { desc } = await inquirer.prompt<{ desc: string }>([
     { type: 'input', name: 'desc', message: 'Describe what you want:' },
   ]);
   return desc;
 }
 
-export async function pickSuggestion(sugs: Suggestion[], label: string): Promise<Suggestion | null> {
+async function _pickSuggestion(sugs: Suggestion[], label: string): Promise<Suggestion | null> {
   if (sugs.length === 0) return null;
 
   const choices = sugs.map((s, i) => ({
@@ -24,3 +25,6 @@ export async function pickSuggestion(sugs: Suggestion[], label: string): Promise
 
   return sugs[idx];
 }
+
+export const askDescription = withTrace('askDescription', _askDescription);
+export const pickSuggestion = withTrace('pickSuggestion', _pickSuggestion);


### PR DESCRIPTION
## Summary
- add lightweight `withTrace` helper that loads LangSmith tracing when available
- wrap prompt, intent, planning, and cart link steps with tracing
- declare `langsmith` dependency for optional tracing support

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/langsmith)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6f24b6a6c83258209eb432dc87f74